### PR TITLE
NO-JIRA - Ensure we keep CA certificates updated in the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="operations@invoca.com"
 
 ENV BUILD_DEPS '\
     apt-transport-https \
+    ca-certificates \
     cron \
     curl \
     dnsutils \

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -38,6 +38,7 @@ describe "Docker Image" do
     'tail',
     'top',      # procps
     'tr',
+    'update-ca-certificates',
     'vim',
   ].each do |pkg|
     describe command("which #{pkg}") do


### PR DESCRIPTION
## Context

Before I was off I was running into:
```
kitestring-reconciler-live-767ddd5fc7-hghf6 reconciler {"level":"warn","error":"Post \"https://graphql.buildkite.com/v1\": x509: certificate signed by unknown authority","time":"2021-03-31T20:55:29Z","message":"error reconciling job queue with tags [queue=chef]: &url.Error{Op:\"Post\", URL:\"https://graphql.buildkite.com/v1\", Err:x509.UnknownAuthorityError{Cert:(*x509.Certificate)(0xc000418680), hintErr:error(nil), hintCert:(*x509.Certificate)(nil)}}"}
```
with `kitestring` which is built on top of our `invocaops/base` image.

Rather than having downstream images manage getting or running `update-ca-certificates` I'd rather just have it in `invocaops/base`.

## Note

This could be solved by just rebuilding `invocaops/base` weekly/month as well given an upstream of `debian:9` but I like that this is explicit in we want up-to-date CA certificates.